### PR TITLE
Fixed gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.lock
+target/


### PR DESCRIPTION
Ignores compiled "target" directory

Because can. 