### PR TITLE
Remove bufreader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,11 @@ impl Fileinfo{
                 /* We want a read call to be "large" for two reasons
                 1) Force filesystem read ahead behavior
                 2) Fewer system calls for a given file.
-                Currently 64KB which is half of a default RHEL read ahead buffer */
-                let mut hash_buffer = [0;BLOCK_SIZE * 16];
+                Currently 16KB  */
+                let mut hash_buffer = [0;BLOCK_SIZE * 4];
                 loop {
                     match f.read(&mut hash_buffer) {
-                        Ok(n) if n>0 => hasher.write(&hash_buffer[0..]),
+                        Ok(n) if n>0 => hasher.write(&hash_buffer),
                         Ok(n) if n==0 => break,
                         Err(_e) => {
                             return None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::fs::{self, DirEntry};
 use std::io::{Read, BufReader};
 use std::path::{PathBuf, Path};
 use std::cmp::Ordering;
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::{Serialize};
 use siphasher::sip128::Hasher128;
 use rayon::prelude::*;
 use std::sync::mpsc::{Sender, channel};
@@ -27,7 +27,7 @@ enum ChannelPackage{
 }
 
 /// Serializable struct containing entries for a specific file.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 pub struct Fileinfo{
     full_hash: Option<u128>,
     partial_hash: Option<u128>,


### PR DESCRIPTION
This PR removes  the bufreader layer in front of file reads and achieves a lower system call count as a result. Run time performance on my laptop is in line with the bufreader. The reason this works as well as the bufreader approach is that the filesystem (most filesystems) has a feature called a read ahead buffer  
https://lwn.net/Articles/155510/  
and so this PR can be seen as a reduction of the use of two buffers to one. My testing was done on apples APFS and while I can't find documentation on the read ahead behavior it does seem to work as expected. The rust bufreader uses an 8KB buffer at time of writing so by using a 16KB buffer this PR sees a roughly 50% reduction in system calls.