### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+
+*.lock
+target/
+Results.txt
+.DS_Store
+
+.github
+*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.42.0 as builder
+
+WORKDIR /ddh/
+
+COPY . /ddh/
+RUN cargo install --path /ddh/
+
+
+FROM debian:10.3-slim
+
+LABEL org.label-schema.vcs-url="https://github.com/darakian/ddh"
+
+COPY --from=builder /usr/local/cargo/bin/ddh /usr/local/bin/ddh
+
+WORKDIR /target/
+
+CMD ["ddh"]


### PR DESCRIPTION
This `Dockerfile` uses a multi-stage Docker build to produce a
relatively minimal image for the `ddh` tool.

Once built, it can be used like so:

```
docker run --rm \
    -v "$(pwd):/target/:ro" \
    -v "/my-host-results-dir/:/results/" \
    <ddh image> \
    ddh . --output /results/results_1.txt
```

This way, you can safely check for duplicates in your current working
directory (marked as read-only), and write results to a separate directory
(e.g. `/my-host-results-dir/` in the example above).

For users without Rust installed on their machines, this may be
an easier execution option that is relatively platform agnostic.

TODO:

- Hook build, and publish to CI
- Update README.md to include instructions on running with Docker