### PR TITLE
Remove serde-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = "2.33.0"
 rayon = "1.3"
 serde = "1.0"
 serde_json = "1.0"
-serde_derive = "1.0"
 siphasher = "0.3"
 nohash-hasher = "0.1.1"
 


### PR DESCRIPTION
This PR implements serialize for Fileinfo and removes serde derive.
This speeds up compile time.