### PR TITLE
Add metadata as new entry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ fn traverse_and_spawn(current_path: &Path, sender: Sender<ChannelPackage>) -> ()
             Fileinfo::new(
                 None,
                 None,
-                current_path.metadata().expect("Error reading path length").len(),
+                current_path.metadata().expect("Error reading file metadata"),
                 current_path.to_path_buf()
                 ))
             ).expect("Error sending new ChannelPackage::Success");
@@ -100,7 +100,7 @@ fn traverse_and_spawn(current_path: &Path, sender: Sender<ChannelPackage>) -> ()
                             Fileinfo::new(
                                 None,
                                 None,
-                                x.metadata().expect("Error reading path length").len(),
+                                current_path.metadata().expect("Error reading file metadata"),
                                 x.path()))
                                 ).expect("Error sending new ChannelPackage::Success")
                             );


### PR DESCRIPTION
Alter the fileinfo struct to work with an fs::Metadata iter rather than accessing length
immediately. File length access is maintained by altering the get_length() function
to reference the metadata and by using the struct get_length() function as opposed
to direct access.