### PR TITLE
Fix for ignore-dir optional argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,10 @@ fn main() {
 
     //let (sender, receiver) = channel();
     let search_dirs: Vec<_> = arguments.values_of("directories").unwrap().collect();
-    let ignore_dirs: Vec<_> = arguments.values_of("ignore").unwrap().collect();
+    let mut ignore_dirs: Vec<&str> = Vec::new();
+    if let Some(dirs) = arguments.values_of("ignore"){
+        ignore_dirs.append(&mut dirs.collect::<Vec<&str>>());
+    };
     let min_size: u64 = arguments.value_of("Minimum").unwrap().parse::<u64>().unwrap_or(0);
 
     let (complete_files, read_errors): (Vec<Fileinfo>, Vec<(_, _)>) =


### PR DESCRIPTION
Without "ignore dir" optional argument (-i), ddh cli (main.rs) panics.
Just test to see if Value iterator for "ignore" is not null before calling collect().