### PR TITLE
cli: suppress unused option PrintFmt::Off

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FLAGS:
 OPTIONS:
     -b, --blocksize <Blocksize>    Sets the display blocksize to Bytes, Kilobytes, Megabytes or Gigabytes. Default is
                                    Kilobytes. [possible values: B, K, M, G]
-    -f, --format <Format>          Sets output format. [possible values: standard, json, off]
+    -f, --format <Format>          Sets output format. [possible values: standard, json]
     -o, --output <Output>          Sets file to save all output. Use 'no' for no file output.
     -v, --verbosity <Verbosity>    Sets verbosity for printed output. [possible values: quiet, duplicates, all]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use std::path::PathBuf;
 pub enum PrintFmt {
     Standard,
     Json,
-    Off,
 }
 
 pub enum Verbosity {
@@ -66,7 +65,7 @@ fn main() {
                         .arg(Arg::new("Format")
                                 .short('f')
                                 .long("format")
-                                .possible_values(&["standard", "json", "off"])
+                                .possible_values(&["standard", "json"])
                                 .takes_value(true)
                                 .max_values(1)
                                 .help("Sets output format."))
@@ -242,7 +241,6 @@ fn process_full_output(
                 serde_json::to_string(complete_files).unwrap_or_else(|_| "".to_string())
             );
         }
-        _ => {}
     }
 
     match arguments.value_of("Output").unwrap_or("Results.txt") {
@@ -336,7 +334,6 @@ fn write_results_to_file(
                 ))
                 .unwrap();
         }
-        PrintFmt::Off => return,
     }
     println!("{:#?} results written to {}", fmt, file);
 }


### PR DESCRIPTION
Format (cli option) can match standard or json (Off is not tested in match expression and is useless)