### PR TITLE
Clap 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ddh"
 readme = "README.md"
 
 [dependencies]
-clap = "3"
+clap = { version = "4.0.0", features = ["derive"] }
 rayon = "1.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -32,25 +32,24 @@ DDH supports both a `standard` output for human comprehension and a parsable `js
 Directory Difference hTool
 Jon Moroney jmoroney@hawaii.edu
 Compare and contrast directories.
-Example invocation: ddh -d /home/jon/downloads /home/jon/documents -v duplicates
-Example pipe: ddh -d ~/Downloads/ -o no -v all -f json | someJsonParser.bin
 
-USAGE:
-    ddh [OPTIONS] <Directories>...
+Example invocation: ddh -v duplicates /home/jon/downloads /home/jon/documents
+Example pipe: ddh -o no -v all -f json ~/Downloads/ | someJsonParser.bin
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+Usage: ddh [OPTIONS] <DIRECTORIES>...
 
-OPTIONS:
-    -b, --blocksize <Blocksize>    Sets the display blocksize to Bytes, Kilobytes, Megabytes or Gigabytes. Default is
-                                   Kilobytes. [possible values: B, K, M, G]
-    -f, --format <Format>          Sets output format. [possible values: standard, json]
-    -o, --output <Output>          Sets file to save all output. Use 'no' for no file output.
-    -v, --verbosity <Verbosity>    Sets verbosity for printed output. [possible values: quiet, duplicates, all]
+Arguments:
+  <DIRECTORIES>...  Directories to parse
 
-ARGS:
-    <Directories>...    Directories to parse
+Options:
+  -m, --minimum [<MIN_SIZE>]     Minimum file size in bytes to consider [default: 0]
+  -b, --blocksize [<BLOCKSIZE>]  Set the display blocksize to Bytes, Kilobytes, Megabytes or Gigabytes [default: K] [possible values: B, K, M, G]
+  -v, --verbosity [<VERBOSITY>]  Set verbosity for printed output [default: quiet] [possible values: quiet, duplicates, all]
+  -o, --output [<OUTPUT>]        Set file to save all output. Use 'no' for no file output [default: Results.txt]
+  -f, --format [<FMT>]           Set output format [default: standard] [possible values: standard, json]
+  -i, --ignore <IGNORE_DIRS>     Directories to ignore (comma separated list)
+  -h, --help                     Print help information (use `--help` for more detail)
+  -V, --version                  Print version information
 ```
 ## How Does DDH Work?
 DDH works by hashing files to determine their uniqueness and, as such, depends heavily on disk speeds for performance. The algorithmic choices in use are discussed [here](https://darakian.github.io/2018/04/02/how-many-bytes-does-it-take.html).

--- a/README.md
+++ b/README.md
@@ -33,23 +33,30 @@ Directory Difference hTool
 Jon Moroney jmoroney@hawaii.edu
 Compare and contrast directories.
 
-Example invocation: ddh -v duplicates /home/jon/downloads /home/jon/documents
-Example pipe: ddh -o no -v all -f json ~/Downloads/ | someJsonParser.bin
+Example invocation: ddh -v duplicates -d /home/jon/downloads /home/jon/documents
+Example pipe: ddh -o no -v all -f json -d ~/Downloads/ | someJsonParser.bin
 
-Usage: ddh [OPTIONS] <DIRECTORIES>...
-
-Arguments:
-  <DIRECTORIES>...  Directories to parse
+Usage: ddh [OPTIONS]
 
 Options:
-  -m, --minimum [<MIN_SIZE>]     Minimum file size in bytes to consider [default: 0]
-  -b, --blocksize [<BLOCKSIZE>]  Set the display blocksize to Bytes, Kilobytes, Megabytes or Gigabytes [default: K] [possible values: B, K, M, G]
-  -v, --verbosity [<VERBOSITY>]  Set verbosity for printed output [default: quiet] [possible values: quiet, duplicates, all]
-  -o, --output [<OUTPUT>]        Set file to save all output. Use 'no' for no file output [default: Results.txt]
-  -f, --format [<FMT>]           Set output format [default: standard] [possible values: standard, json]
-  -i, --ignore <IGNORE_DIRS>     Directories to ignore (comma separated list)
-  -h, --help                     Print help information (use `--help` for more detail)
-  -V, --version                  Print version information
+  -m, --minimum [<MIN_SIZE>]
+          Minimum file size in bytes to consider [default: 0]
+  -b, --blocksize [<BLOCKSIZE>]
+          Set the display blocksize to Bytes, Kilobytes, Megabytes or Gigabytes [default: K] [possible values: B, K, M, G]
+  -v, --verbosity [<VERBOSITY>]
+          Set verbosity for printed output [default: quiet] [possible values: quiet, duplicates, all]
+  -o, --output [<OUTPUT>]
+          Set file to save all output. Use 'no' for no file output [default: Results.txt]
+  -f, --format [<FMT>]
+          Set output format [default: standard] [possible values: standard, json]
+  -i, --ignore <IGNORE_DIRS>
+          Directories to ignore (comma separated list)
+  -d, --directories <DIRECTORIES>...
+          Directories to parse
+  -h, --help
+          Print help information (use `--help` for more detail)
+  -V, --version
+          Print version information
 ```
 ## How Does DDH Work?
 DDH works by hashing files to determine their uniqueness and, as such, depends heavily on disk speeds for performance. The algorithmic choices in use are discussed [here](https://darakian.github.io/2018/04/02/how-many-bytes-does-it-take.html).

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct Args {
     #[arg(short, long("ignore"), value_delimiter(','))]
     ignore_dirs: Vec<String>,
     /// Directories to parse
-    #[arg(value_parser, required = true)]
+    #[arg(short, long("directories"), value_delimiter(' '), num_args(1..), required = true)]
     directories: Vec<String>,
 }
 


### PR DESCRIPTION
Always polishing the cli :)
Now I've used the new shinny clap derive api.

Some minor changes:
1) directories is now a mandatory positional argument (no -d flag):
```
$ cargo run -- -f json  -o=no src
4 Total files (with duplicates): 24 Kilobytes
4 Total files (without duplicates): 24 Kilobytes
4 Single instance files: 24 Kilobytes
0 Shared instance files: 0 Kilobytes (0 instances)

$ cargo run -- -f json  -o=no 
error: The following required arguments were not provided:
  <DIRECTORIES>...

Usage: ddh --format [<FMT>] --output [<OUTPUT>] <DIRECTORIES>...

For more information try '--help'
```
2) ignore_dirs are a comma separated list (or you can repeat the -i flags):

```
$ cargo run -- -f json -i target/debug/.fingerprint/,target/debug -o=no .
156 Total files (with duplicates): 441 Kilobytes
150 Total files (without duplicates): 441 Kilobytes
145 Single instance files: 441 Kilobytes
5 Shared instance files: 0 Kilobytes (11 instances)

$ cargo run -- -f json -i target/debug/.fingerprint/ -i target/debug -o=no .
156 Total files (with duplicates): 441 Kilobytes
150 Total files (without duplicates): 441 Kilobytes
145 Single instance files: 441 Kilobytes
5 Shared instance files: 0 Kilobytes (11 instances)
```
